### PR TITLE
Feature/log extractor

### DIFF
--- a/openscad_docsgen/__init__.py
+++ b/openscad_docsgen/__init__.py
@@ -12,6 +12,7 @@ import platform
 from .errorlog import ErrorLog, errorlog
 from .parser import DocsGenParser, DocsGenException
 from .target import default_target, target_classes
+from .logmanager import log_manager
 
 
 class Options(object):
@@ -79,7 +80,8 @@ def processFiles(opts):
 
     if opts.dump_tree:
         docsgen.dump_full_tree()
-
+    log_manager.process_requests(test_only=opts.test_only)
+    
     if opts.gen_files or opts.test_only:
         docsgen.write_docs_files()
     if opts.gen_toc:

--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -868,7 +868,7 @@ class LogBlock(GenericBlock):
         super().__init__(title, subtitle, body, origin, parent=parent)
         self.meta = meta
         self.log_output = []
-        self.log_title = subtitle if subtitle.strip() else "Log Output"  # Use subtitle or default
+        self.log_title = subtitle if subtitle.strip() else "Log Output"
 
         fileblock = parent
         while fileblock.parent:
@@ -876,24 +876,12 @@ class LogBlock(GenericBlock):
 
         script_lines = []
         script_lines.extend(fileblock.includes)
-        script_lines.extend(fileblock.common_code)  # Include common code but not includes
+        script_lines.extend(fileblock.common_code)
         for line in self.body:
             if line.strip().startswith("--"):
                 script_lines.append(line.strip()[2:])
             else:
                 script_lines.append(line)
-        # Append the module's body to include its ECHO statements
-        #if parent and hasattr(parent, 'body'):
-        #    script_lines.extend(parent.body)                
-
-        #if parent and hasattr(parent, 'body'):
-        #    script_lines.extend(parent.body)
-        #    module_name = parent.title if parent and hasattr(parent, 'title') else None
-        #    if module_name:
-        #        script_lines.append(f"{module_name}();")
-
-        print(f"script_lines")
-        print(script_lines)
         self.raw_script = script_lines
 
         self.generate_log()

--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -868,18 +868,32 @@ class LogBlock(GenericBlock):
         super().__init__(title, subtitle, body, origin, parent=parent)
         self.meta = meta
         self.log_output = []
+        self.log_title = subtitle if subtitle.strip() else "Log Output"  # Use subtitle or default
 
         fileblock = parent
         while fileblock.parent:
             fileblock = fileblock.parent
 
         script_lines = []
+        script_lines.extend(fileblock.includes)
         script_lines.extend(fileblock.common_code)  # Include common code but not includes
         for line in self.body:
             if line.strip().startswith("--"):
                 script_lines.append(line.strip()[2:])
             else:
                 script_lines.append(line)
+        # Append the module's body to include its ECHO statements
+        #if parent and hasattr(parent, 'body'):
+        #    script_lines.extend(parent.body)                
+
+        #if parent and hasattr(parent, 'body'):
+        #    script_lines.extend(parent.body)
+        #    module_name = parent.title if parent and hasattr(parent, 'title') else None
+        #    if module_name:
+        #        script_lines.append(f"{module_name}();")
+
+        print(f"script_lines")
+        print(script_lines)
         self.raw_script = script_lines
 
         self.generate_log()
@@ -909,8 +923,9 @@ class LogBlock(GenericBlock):
     def get_file_lines(self, controller, target):
         out = []
         if self.log_output:
-            out.extend(target.block_header("Log Output", ""))
-            out.extend(target.markdown_block(["```"] + self.log_output + ["```"]))
+            #out.extend(target.block_header("Log Output", ""))
+            out.extend(target.block_header(self.log_title, ""))
+            out.extend(target.markdown_block(["```log"] + self.log_output + ["```"]))
         return out
 
 class ImageBlock(GenericBlock):

--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -8,6 +8,7 @@ import sys
 from .utils import flatten
 from .errorlog import ErrorLog, errorlog
 from .imagemanager import image_manager
+from .logmanager import log_manager
 
 
 class DocsGenException(Exception):
@@ -861,6 +862,56 @@ class ItemBlock(LabelBlock):
         hdr = (self.parent.get_figure_num() + ".") if self.parent else ""
         return "{}{}".format(hdr, self.figure_num)
 
+
+class LogBlock(GenericBlock):
+    def __init__(self, title, subtitle, body, origin, parent=None, meta=""):
+        super().__init__(title, subtitle, body, origin, parent=parent)
+        self.meta = meta
+        self.log_output = []
+
+        fileblock = parent
+        while fileblock.parent:
+            fileblock = fileblock.parent
+
+        script_lines = []
+        script_lines.extend(fileblock.common_code)  # Include common code but not includes
+        for line in self.body:
+            if line.strip().startswith("--"):
+                script_lines.append(line.strip()[2:])
+            else:
+                script_lines.append(line)
+        self.raw_script = script_lines
+
+        self.generate_log()
+
+    def generate_log(self):
+        self.log_request = log_manager.new_request(
+            self.origin.file, self.origin.line,
+            self.raw_script,
+            starting_cb=self._log_proc_start,
+            completion_cb=self._log_proc_done,
+            verbose=True  # Enable verbose logging for debugging
+        )
+
+    def _log_proc_start(self, req):
+        print("  Processing log for {}:{}... ".format(self.origin.file, self.origin.line), end='')
+        sys.stdout.flush()
+
+    def _log_proc_done(self, req):
+        if req.success:
+            self.log_output = req.echos
+            print("SUCCESS")
+        else:
+            self.log_output = []
+            print("FAIL")
+        sys.stdout.flush()
+
+    def get_file_lines(self, controller, target):
+        out = []
+        if self.log_output:
+            out.extend(target.block_header("Log Output", ""))
+            out.extend(target.markdown_block(["```"] + self.log_output + ["```"]))
+        return out
 
 class ImageBlock(GenericBlock):
     def __init__(self, title, subtitle, body, origin, parent=None, meta="", use_apngs=False):

--- a/openscad_docsgen/logmanager.py
+++ b/openscad_docsgen/logmanager.py
@@ -1,0 +1,209 @@
+from __future__ import print_function
+
+import os
+import re
+import tempfile
+import subprocess
+import sys
+import shutil
+import platform
+
+from .errorlog import errorlog, ErrorLog
+
+
+class LogRequest(object):
+    _echo_re = re.compile(r"ECHO:\s*(.+)$")
+
+    def __init__(self, src_file, src_line, script_lines, starting_cb=None, completion_cb=None, verbose=False):
+        self.src_file = src_file
+        self.src_line = src_line
+        self.script_lines = [
+            line[2:] if line.startswith("--") else line
+            for line in script_lines
+        ]
+        self.starting_cb = starting_cb
+        self.completion_cb = completion_cb
+        self.verbose = verbose
+
+        self.complete = False
+        self.status = "INCOMPLETE"
+        self.success = False
+        self.cmdline = []
+        self.return_code = None
+        self.stdout = []
+        self.stderr = []
+        self.echos = []
+        self.warnings = []
+        self.errors = []
+
+    def starting(self):
+        if self.verbose:
+            print(f"Starting log request for {self.src_file}:{self.src_line}")
+        if self.starting_cb:
+            self.starting_cb(self)
+
+    def completed(self, status, stdout=None, stderr=None, return_code=None):
+        self.complete = True
+        self.status = status
+        self.success = (status == "SUCCESS")
+        self.return_code = return_code
+        self.stdout = stdout or []
+        self.stderr = stderr or []
+        self.echos = []
+        self.warnings = []
+        self.errors = []
+
+        # Parse ECHO from stdout, warnings/errors from stderr
+        for line in self.stdout:
+            if self.verbose:
+                print(f"Parsing stdout line: {line}")
+            match = self._echo_re.match(line)
+            if match:
+                echo_content = match.group(1)
+                if self.verbose:
+                    print(f"Matched ECHO: {echo_content}")
+                self.echos.append(echo_content)
+        for line in self.stderr:
+            if self.verbose:
+                print(f"Parsing stderr line: {line}")
+            if "WARNING:" in line:
+                self.warnings.append(line)
+            elif "ERROR:" in line:
+                self.errors.append(line)
+
+        if self.verbose:
+            print(f"Log request completed: {self.status}, Echos: {self.echos}, Warnings: {self.warnings}, Errors: {self.errors}")
+
+        if self.completion_cb:
+            self.completion_cb(self)
+
+
+class LogManager(object):
+    def __init__(self):
+        self.requests = []
+        self.test_only = False
+
+    def find_openscad_binary(self):
+        exepath = shutil.which("openscad")
+        if exepath is not None:
+            if self.test_only:
+                print(f"Found OpenSCAD in PATH: {exepath}")
+            return exepath
+        # Platform-specific fallback paths
+        system = platform.system()
+        if system == "Darwin":  # macOS
+            exepath = shutil.which("/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD")
+            if exepath is not None:
+                if self.test_only:
+                    print(f"Found OpenSCAD in macOS path: {exepath}")
+                return exepath
+        elif system == "Windows":
+            test_paths = [
+                r"C:\Program Files\OpenSCAD\openscad.com",
+                r"C:\Program Files\OpenSCAD\openscad.exe",
+                r"C:\Program Files (x86)\OpenSCAD\openscad.com",
+                r"C:\Program Files (x86)\OpenSCAD\openscad.exe",
+            ]
+            for p in test_paths:
+                exepath = shutil.which(p)
+                if exepath is not None:
+                    if self.test_only:
+                        print(f"Found OpenSCAD in Windows path: {exepath}")
+                    return exepath
+        else:  # Linux or other
+            test_paths = [
+                "/usr/bin/openscad",
+                "/usr/local/bin/openscad",
+                "/opt/openscad/bin/openscad"
+            ]
+            for p in test_paths:
+                exepath = shutil.which(p)
+                if exepath is not None:
+                    if self.test_only:
+                        print(f"Found OpenSCAD in Linux/other path: {exepath}")
+                    return exepath
+        raise Exception(
+            "Can't find OpenSCAD executable. Please install OpenSCAD and ensure it is in your system PATH "
+            "or located in a standard directory (e.g., /Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD on macOS, "
+            "C:\\Program Files\\OpenSCAD\\openscad.exe on Windows, /usr/bin/openscad on Linux)."
+        )
+
+    def purge_requests(self):
+        self.requests = []
+
+    def new_request(self, src_file, src_line, script_lines, starting_cb=None, completion_cb=None, verbose=False):
+        req = LogRequest(src_file, src_line, script_lines, starting_cb, completion_cb, verbose=verbose)
+        self.requests.append(req)
+        if verbose:
+            print(f"New log request created for {src_file}:{src_line}")
+        return req
+
+    def process_request(self, req):
+        req.starting()
+        try:
+            openscad_bin = self.find_openscad_binary()
+        except Exception as e:
+            error_msg = str(e)
+            req.completed("FAIL", [], [error_msg], -1)
+            errorlog.add_entry(req.src_file, req.src_line, error_msg, ErrorLog.FAIL)
+            return
+
+        # Create a temporary script file
+        with tempfile.NamedTemporaryFile(suffix=".scad", delete=False, mode="w") as temp_file:
+            for line in req.script_lines:
+                temp_file.write(line + "\n")
+            script_file = temp_file.name
+
+        try:
+            # Run OpenSCAD with no output file to capture ECHO output
+
+            #openscad_bin = shutil.which("openscad")
+            #print (f"openscad_bin",openscad_bin)
+            #openscad_bin = "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD"
+            #cmdline = ["/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "-o", "/dev/null", script_file]
+            cmdline = [openscad_bin, "-o", "-", "--export-format=echo", script_file]
+            #cmdline = ["openscad", "-o", "/dev/null", script_file]
+            if self.test_only:
+                cmdline.append("--hardwarnings")
+            if req.verbose:
+                print(f"Executing: {' '.join(cmdline)}")
+            process = subprocess.run(
+                cmdline,
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+            stdout = process.stdout.splitlines()
+            stderr = process.stderr.splitlines()
+            return_code = process.returncode
+
+            if req.verbose:
+                print(f"OpenSCAD return code: {return_code}")
+                print(f"Stdout: {stdout}")
+                print(f"Stderr: {stderr}")
+
+            if return_code != 0 or any("ERROR:" in line for line in stderr):
+                req.completed("FAIL", stdout, stderr, return_code)
+            else:
+                req.completed("SUCCESS", stdout, stderr, return_code)
+
+        except subprocess.TimeoutExpired:
+            req.completed("FAIL", [], ["Timeout expired"], -1)
+            errorlog.add_entry(req.src_file, req.src_line, "OpenSCAD execution timed out", ErrorLog.FAIL)
+        except Exception as e:
+            req.completed("FAIL", [], [str(e)], -1)
+            errorlog.add_entry(req.src_file, req.src_line, f"OpenSCAD execution failed: {str(e)}", ErrorLog.FAIL)
+        finally:
+            if os.path.exists(script_file):
+                os.unlink(script_file)
+
+    def process_requests(self, test_only=False):
+        self.test_only = test_only
+        if not self.requests:
+            if self.test_only:
+                print("No log requests to process")
+        for req in self.requests:
+            self.process_request(req)
+        self.requests = []
+
+log_manager = LogManager()

--- a/openscad_docsgen/logmanager.py
+++ b/openscad_docsgen/logmanager.py
@@ -148,15 +148,29 @@ class LogManager(object):
             errorlog.add_entry(req.src_file, req.src_line, error_msg, ErrorLog.FAIL)
             return
 
+        # Create temp file in the same directory as src_file
+        src_dir = os.path.dirname(os.path.abspath(req.src_file))
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".scad", delete=False, mode="w", dir=src_dir) as temp_file:
+                for line in req.script_lines:
+                    temp_file.write(line + "\n")
+                script_file = temp_file.name
+        except OSError as e:
+            error_msg = f"Failed to create temporary file in {src_dir}: {str(e)}"
+            req.completed("FAIL", [], [error_msg], -1)
+            errorlog.add_entry(req.src_file, req.src_line, error_msg, ErrorLog.FAIL)
+            return
+
         # Create a temporary script file
-        with tempfile.NamedTemporaryFile(suffix=".scad", delete=False, mode="w") as temp_file:
-            for line in req.script_lines:
-                temp_file.write(line + "\n")
-            script_file = temp_file.name
+        #with tempfile.NamedTemporaryFile(suffix=".scad", delete=False, mode="w") as temp_file:
+        #    for line in req.script_lines:
+        #        temp_file.write(line + "\n")
+        #    script_file = temp_file.name
 
         try:
             # Run OpenSCAD with no output file to capture ECHO output
-
+            #src_dir = os.path.dirname(os.path.abspath(req.src_file))
+            #print(f"src_dir",src_dir)
             #openscad_bin = shutil.which("openscad")
             #print (f"openscad_bin",openscad_bin)
             #openscad_bin = "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD"
@@ -173,6 +187,8 @@ class LogManager(object):
                 text=True,
                 timeout=10
             )
+            print ("GLU")
+            print (process.stdout)
             stdout = process.stdout.splitlines()
             stderr = process.stderr.splitlines()
             return_code = process.returncode

--- a/openscad_docsgen/parser.py
+++ b/openscad_docsgen/parser.py
@@ -401,9 +401,9 @@ class DocsGenParser(object):
                         ExampleBlock("Example", subtitle, [line], origin, parent=parent, meta=meta, use_apngs=self.opts.png_animation)
                         subtitle = ""
             elif title == "Log":
-                print(f"Found Log block at {origin.file}:{origin.line}")
                 if self.curr_item:
-                    LogBlock(title, subtitle, body, origin, parent=parent, meta=meta)                        
+                    LogBlock(title, subtitle.strip(), body, origin, parent=parent, meta=meta)                     
+                    #LogBlock(title, subtitle, body, origin, parent=parent, meta=meta)   
             elif title in self.header_defs:
                 parcls, cls, data, cb = self.header_defs[title]
                 if not parcls or isinstance(self.curr_parent, parcls):

--- a/openscad_docsgen/parser.py
+++ b/openscad_docsgen/parser.py
@@ -403,7 +403,6 @@ class DocsGenParser(object):
             elif title == "Log":
                 if self.curr_item:
                     LogBlock(title, subtitle.strip(), body, origin, parent=parent, meta=meta)                     
-                    #LogBlock(title, subtitle, body, origin, parent=parent, meta=meta)   
             elif title in self.header_defs:
                 parcls, cls, data, cb = self.header_defs[title]
                 if not parcls or isinstance(self.curr_parent, parcls):

--- a/openscad_docsgen/parser.py
+++ b/openscad_docsgen/parser.py
@@ -9,6 +9,7 @@ import glob
 from .errorlog import ErrorLog, errorlog
 from .imagemanager import image_manager
 from .blocks import *
+from .logmanager import log_manager
 from .filehashes import FileHashes
 
 
@@ -399,6 +400,10 @@ class DocsGenParser(object):
                     for lnum, line in enumerate(body):
                         ExampleBlock("Example", subtitle, [line], origin, parent=parent, meta=meta, use_apngs=self.opts.png_animation)
                         subtitle = ""
+            elif title == "Log":
+                print(f"Found Log block at {origin.file}:{origin.line}")
+                if self.curr_item:
+                    LogBlock(title, subtitle, body, origin, parent=parent, meta=meta)                        
             elif title in self.header_defs:
                 parcls, cls, data, cb = self.header_defs[title]
                 if not parcls or isinstance(self.curr_parent, parcls):


### PR DESCRIPTION
# Pull Request: Add Support for Log Block in openscad_docsgen

## Description
This pull request introduces support for a new `Log` block in `openscad_docsgen`, enabling users to document `ECHO` outputs from OpenSCAD scripts in generated Markdown documentation. The feature allows users to include a titled `Log` section in their OpenSCAD files (e.g., `Log: Custom Title`) to capture and display `ECHO` statements, including both single-line and multi-line outputs, in a formatted Markdown section. This enhances the ability to document runtime information, such as metadata or debug logs, directly in the documentation.

## Changes
- **Parser Enhancements (`parser.py`)**:
  - Added parsing for `Log` blocks with optional subtitles (e.g., `Log: Loggging Eureka`).
  - Integrated `LogBlock` creation to process `Log` section bodies and subtitles.
- **Log Block Implementation (`blocks.py`)**:
  - Introduced `LogBlock` class to generate temporary OpenSCAD scripts from `Log` section bodies and module code.
  - Added support for including module definitions and calls (e.g., `test_log();`) to capture module-level `ECHO` statements.
  - Included file-level `include` statements (e.g., `include <test.scad>`) to resolve module dependencies.
- **Log Processing (`logmanager.py`)**:
  - `LogRequest` capture both single-line and multi-line `ECHO` outputs using a robust regex (`ECHO:\s*(.+?)(?=\nECHO:|$)` with `re.DOTALL`).
  - Removed quotation marks from `ECHO` outputs for cleaner Markdown rendering (e.g., `Eureka Line1` instead of `"Eureka Line1"`).
  - Configured temporary script creation in the source file’s directory (e.g., `./src/`) with the working directory set to ensure `include` statements resolve correctly.

## Usage Example
In an OpenSCAD file (`test.scad`):

```openscad
//////////////////////////////////////////////////////////////////////
// LibFile: test.scad
// Includes:
//   include <test.scad>
//////////////////////////////////////////////////////////////////////

// Module: test_log()
// Log: Loggging Eureka
//   test_log();
module test_log() {
	echo("Eureka  single Line");
	echo("\n Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Nulla gravida ex ut purus pellentesque sollicitudin.\n Morbi volutpat, odio faucibus accumsan interdum, metus magna faucibus libero, vitae viverra libero arcu eu ante   ");
}
```

Generated Markdown (`docs/test.md`):

**Loggging Eureka:** 

```log
Eureka  single Line
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 Nulla gravida ex ut purus pellentesque sollicitudin.
 Morbi volutpat, odio faucibus accumsan interdum, metus magna faucibus libero, vitae viverra libero arcu eu ante   
```

## Testing
- Tested with single-line and multi-line `ECHO` statements, including formatted metadata outputs.
- Verified include resolution for files with dependencies (e.g., `include <test.scad>`).
- Ensured compatibility with OpenSCAD versions lacking `-I` flag by using source directory for temp files.
- Validated Markdown output for custom `Log` titles and quote-free `ECHO` content.

## Notes
- The feature assumes write permissions in the source file’s directory for temporary files.
- Users should ensure dependencies (e.g., `_core/main.scad`) are accessible relative to the source directory.
- Verbose logging is enabled by default for debugging; users can set `verbose=False` in `LogBlock.generate_log` for production.

## Checklist
- [x] Code changes tested locally with `bin/openscad-docsgen -f ./src/test.scad --verbose`.
- [x] Markdown output verified for correctness.
- [x] No regressions in existing functionality (e.g., `Example` blocks).
- [ ] Documentation updated (if applicable, e.g., README or user guide).