### PR TITLE
Add Support for Default ColorScheme in openscad-docsgen

### DIFF
--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -909,7 +909,7 @@ class ImageBlock(GenericBlock):
         self.image_url_rel = os.path.join("images", file_base, proposed_name)
         self.image_url = os.path.join(file_dir, self.image_url_rel)
 
-    def generate_image(self, target):
+    def generate_image(self, target, parser=None):
         self.image_req = None
         if "NORENDER" in self.meta:
             return
@@ -922,12 +922,13 @@ class ImageBlock(GenericBlock):
             outfile = os.path.join(target.docs_dir, self.image_url)
             outdir = os.path.dirname(outfile)
             os.makedirs(outdir, mode=0o744, exist_ok=True)
-
+            default_colorscheme = parser.default_colorscheme if parser else "Cornfield"
             self.image_req = image_manager.new_request(
                 self.origin.file, self.origin.line,
                 outfile, self.raw_script, self.meta,
                 starting_cb=self._img_proc_start,
-                completion_cb=self._img_proc_done
+                completion_cb=self._img_proc_done,
+                default_colorscheme=default_colorscheme
             )
 
     def get_data(self):
@@ -973,7 +974,7 @@ class ImageBlock(GenericBlock):
         if "Hide" in self.meta:
             return out
 
-        self.generate_image(target)
+        self.generate_image(target, controller)
 
         code = []
         code.extend([line for line in fileblock.includes])

--- a/openscad_docsgen/imagemanager.py
+++ b/openscad_docsgen/imagemanager.py
@@ -25,7 +25,7 @@ class ImageRequest(object):
     _vpf_re = re.compile(r'VPF *= *([a-zA-Z0-9_()+*/$.-]+)')
     _color_scheme_re = re.compile(r'ColorScheme *= *([a-zA-Z0-9_ ]+)')
 
-    def __init__(self, src_file, src_line, image_file, script_lines, image_meta, starting_cb=None, completion_cb=None, verbose=False):
+    def __init__(self, src_file, src_line, image_file, script_lines, image_meta, starting_cb=None, completion_cb=None, verbose=False, default_colorscheme="Cornfield"):
         self.src_file = src_file
         self.src_line = src_line
         self.image_file = image_file
@@ -48,7 +48,7 @@ class ImageRequest(object):
         self.show_scales = "NoScales" not in image_meta
         self.orthographic = "Perspective" not in image_meta
         self.script_under = False
-        self.color_scheme = ColorScheme.cornfield.value
+        self.color_scheme = default_colorscheme 
 
         if "ThrownTogether" in image_meta:
             self.render_mode = RenderMode.thrown_together
@@ -200,10 +200,10 @@ class ImageManager(object):
     def purge_requests(self):
         self.requests = []
 
-    def new_request(self, src_file, src_line, image_file, script_lines, image_meta, starting_cb=None, completion_cb=None, verbose=False):
+    def new_request(self, src_file, src_line, image_file, script_lines, image_meta, starting_cb=None, completion_cb=None, verbose=False, default_colorscheme="Cornfield"):
         if "NORENDER" in image_meta:
             raise Exception("Cannot render scripts marked NORENDER")
-        req = ImageRequest(src_file, src_line, image_file, script_lines, image_meta, starting_cb, completion_cb, verbose=verbose)
+        req = ImageRequest(src_file, src_line, image_file, script_lines, image_meta, starting_cb, completion_cb, verbose=verbose,default_colorscheme=default_colorscheme)
         self.requests.append(req)
         return req
 

--- a/openscad_docsgen/parser.py
+++ b/openscad_docsgen/parser.py
@@ -47,6 +47,7 @@ class DocsGenParser(object):
         self.definitions = {}
         self.defn_aliases = {}
         self.syntags_data = {}
+        self.default_colorscheme = "Cornfield"
 
         sfx = self.target.get_suffix()
         self.TOCFILE = "TOC" + sfx
@@ -89,6 +90,17 @@ class DocsGenParser(object):
         self.curr_item.aliases.extend(aliases)
         for alias in aliases:
             self.items_by_name[alias] = self.curr_item
+
+    def _validate_colorscheme(self, colorscheme):
+        """Validate the color scheme against OpenSCAD's supported schemes."""
+        valid_schemes = [
+            'Cornfield', 'Metallic', 'Sunset', 'Starnight', 'ClearSky', 'BeforeDawn', 'Nature', 'Daylight Gem', 'Nocturnal Gem', 
+            'DeepOcean', 'Solarized', 'Tomorrow', 'Tomorrow Night' 
+        ]
+        if colorscheme not in valid_schemes:
+            errorlog.add_entry(self.RCFILE, 0, f"Invalid ColorScheme '{colorscheme}' in {self.RCFILE}. Using 'Cornfield'.", ErrorLog.WARNING)
+            return 'Cornfield'
+        return colorscheme
 
     def _skip_lines(self, lines, line_num=0):
         while line_num < len(lines):
@@ -203,6 +215,14 @@ class DocsGenParser(object):
             origin = OriginInfo(src_file, hdr_line_num+1)
             if title == "DefineHeader":
                 self._define_blocktype(subtitle, meta)
+            elif title == "ColorScheme":
+                if origin.file != self.RCFILE:
+                    raise DocsGenException(title, f"Block disallowed outside of {self.RCFILE} file:")
+                if body:
+                    raise DocsGenException(title, "Body not supported, while declaring block:")
+                if not subtitle:
+                    raise DocsGenException(title, "Must provide a color scheme (e.g., Tomorrow), while declaring block:")
+                self.default_colorscheme = self._validate_colorscheme(subtitle.strip())
             elif title == "IgnoreFiles":
                 if origin.file != self.RCFILE:
                     raise DocsGenException(title, "Block disallowed outside of {} file:".format(self.RCFILE))


### PR DESCRIPTION
## Description

This PR introduces a feature to `openscad-docsgen` that allows setting a default color scheme via the `ColorScheme` directive in `.openscad_docsgen_rc`, ensuring `Example` and `Figure` blocks without an explicit `ColorScheme` use this default. The changes ensure that explicit `ColorScheme` settings take precedence, while the default applies otherwise, improving consistency and user control over documentation rendering.

## Changes

1. **Enhanced `parser.py` to Parse Default ColorScheme**:
   - Updated `_parse_block` to correctly process `// ColorScheme: <value>` in `.openscad_docsgen_rc`, setting `parser.default_colorscheme` (e.g., to `ClearSky`).
2. **Propagated `default_colorscheme` to Image Generation**:
   - Modified `blocks.py` (`ImageBlock.generate_image`) to pass `parser.default_colorscheme` to `image_manager.new_request`.
   - Updated `imagemanager.py` (`ImageRequest.__init__`) to use `default_colorscheme` when no `ColorScheme` is specified in `image_meta`, ensuring blocks like `// Example(3D)` use `ClearSky`.

## Impact

- `Example` and `Figure` blocks without a `ColorScheme` in their metadata now use the default specified in `.openscad_docsgen_rc` (e.g., `ClearSky`).
- Explicit `ColorScheme` settings (e.g., `Solarized` in `// Example(3D,Big,ColorScheme=Solarized)`) are respected, maintaining flexibility.