### PR TITLE
Add ColorScheme Support to openscad-mdimggen for Consistent Documentation Rendering

### DIFF
--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -909,7 +909,7 @@ class ImageBlock(GenericBlock):
         self.image_url_rel = os.path.join("images", file_base, proposed_name)
         self.image_url = os.path.join(file_dir, self.image_url_rel)
 
-    def generate_image(self, target):
+    def generate_image(self, target, parser=None):
         self.image_req = None
         if "NORENDER" in self.meta:
             return
@@ -922,12 +922,13 @@ class ImageBlock(GenericBlock):
             outfile = os.path.join(target.docs_dir, self.image_url)
             outdir = os.path.dirname(outfile)
             os.makedirs(outdir, mode=0o744, exist_ok=True)
-
+            default_colorscheme = parser.default_colorscheme if parser else "Cornfield"
             self.image_req = image_manager.new_request(
                 self.origin.file, self.origin.line,
                 outfile, self.raw_script, self.meta,
                 starting_cb=self._img_proc_start,
-                completion_cb=self._img_proc_done
+                completion_cb=self._img_proc_done,
+                default_colorscheme=default_colorscheme
             )
 
     def get_data(self):
@@ -973,7 +974,7 @@ class ImageBlock(GenericBlock):
         if "Hide" in self.meta:
             return out
 
-        self.generate_image(target)
+        self.generate_image(target, controller)
 
         code = []
         code.extend([line for line in fileblock.includes])

--- a/openscad_docsgen/imagemanager.py
+++ b/openscad_docsgen/imagemanager.py
@@ -25,7 +25,7 @@ class ImageRequest(object):
     _vpf_re = re.compile(r'VPF *= *([a-zA-Z0-9_()+*/$.-]+)')
     _color_scheme_re = re.compile(r'ColorScheme *= *([a-zA-Z0-9_ ]+)')
 
-    def __init__(self, src_file, src_line, image_file, script_lines, image_meta, starting_cb=None, completion_cb=None, verbose=False):
+    def __init__(self, src_file, src_line, image_file, script_lines, image_meta, starting_cb=None, completion_cb=None, verbose=False, default_colorscheme="Cornfield"):
         self.src_file = src_file
         self.src_line = src_line
         self.image_file = image_file
@@ -48,7 +48,7 @@ class ImageRequest(object):
         self.show_scales = "NoScales" not in image_meta
         self.orthographic = "Perspective" not in image_meta
         self.script_under = False
-        self.color_scheme = ColorScheme.cornfield.value
+        self.color_scheme = default_colorscheme 
 
         if "ThrownTogether" in image_meta:
             self.render_mode = RenderMode.thrown_together
@@ -200,10 +200,10 @@ class ImageManager(object):
     def purge_requests(self):
         self.requests = []
 
-    def new_request(self, src_file, src_line, image_file, script_lines, image_meta, starting_cb=None, completion_cb=None, verbose=False):
+    def new_request(self, src_file, src_line, image_file, script_lines, image_meta, starting_cb=None, completion_cb=None, verbose=False, default_colorscheme="Cornfield"):
         if "NORENDER" in image_meta:
             raise Exception("Cannot render scripts marked NORENDER")
-        req = ImageRequest(src_file, src_line, image_file, script_lines, image_meta, starting_cb, completion_cb, verbose=verbose)
+        req = ImageRequest(src_file, src_line, image_file, script_lines, image_meta, starting_cb, completion_cb, verbose=verbose,default_colorscheme=default_colorscheme)
         self.requests.append(req)
         return req
 

--- a/openscad_docsgen/mdimggen.py
+++ b/openscad_docsgen/mdimggen.py
@@ -93,11 +93,10 @@ class MarkdownImageGen(object):
                             fname = "{}_{}.{}".format(fileroot, imgnum, fext)
                             img_rel_url = os.path.join(opts.image_root, fname)
                             imgfile = os.path.join(opts.docs_dir, img_rel_url)
-                            print ("opts.colorscheme",opts.colorscheme)
                             image_manager.new_request(
                                 fileroot+".md", linenum,
                                 imgfile, script, extyp,
-                                colorscheme=opts.colorscheme,
+                                default_colorscheme=opts.colorscheme,
                                 starting_cb=self.img_started,
                                 completion_cb=self.img_completed
                             )
@@ -138,7 +137,6 @@ def mdimggen_main():
             data = yaml.safe_load(f)
         if data is not None:
             defaults = data
-    print("defaults",defaults)
     parser = argparse.ArgumentParser(prog='openscad-mdimggen')
     parser.add_argument('-D', '--docs-dir', default=defaults.get("docs_dir", "docs"),
                         help='The directory to put generated documentation in.')

--- a/openscad_docsgen/mdimggen.py
+++ b/openscad_docsgen/mdimggen.py
@@ -93,9 +93,11 @@ class MarkdownImageGen(object):
                             fname = "{}_{}.{}".format(fileroot, imgnum, fext)
                             img_rel_url = os.path.join(opts.image_root, fname)
                             imgfile = os.path.join(opts.docs_dir, img_rel_url)
+                            print ("opts.colorscheme",opts.colorscheme)
                             image_manager.new_request(
                                 fileroot+".md", linenum,
                                 imgfile, script, extyp,
+                                colorscheme=opts.colorscheme,
                                 starting_cb=self.img_started,
                                 completion_cb=self.img_completed
                             )
@@ -136,7 +138,7 @@ def mdimggen_main():
             data = yaml.safe_load(f)
         if data is not None:
             defaults = data
-
+    print("defaults",defaults)
     parser = argparse.ArgumentParser(prog='openscad-mdimggen')
     parser.add_argument('-D', '--docs-dir', default=defaults.get("docs_dir", "docs"),
                         help='The directory to put generated documentation in.')
@@ -151,6 +153,8 @@ def mdimggen_main():
     parser.add_argument('-a', '--png-animation', action="store_true",
                         default=defaults.get("png_animations", True),
                         help='If given, animations are created using animated PNGs instead of GIFs.')
+    parser.add_argument('-C', '--colorscheme', default=defaults.get("ColorScheme", "Cornfield"),
+                        help='The color scheme for rendering images (e.g., Tomorrow).')    
     parser.add_argument('srcfiles', nargs='*', help='List of input markdown files.')
     args = parser.parse_args()
 

--- a/openscad_docsgen/parser.py
+++ b/openscad_docsgen/parser.py
@@ -47,6 +47,7 @@ class DocsGenParser(object):
         self.definitions = {}
         self.defn_aliases = {}
         self.syntags_data = {}
+        self.default_colorscheme = "Cornfield"
 
         sfx = self.target.get_suffix()
         self.TOCFILE = "TOC" + sfx
@@ -89,6 +90,17 @@ class DocsGenParser(object):
         self.curr_item.aliases.extend(aliases)
         for alias in aliases:
             self.items_by_name[alias] = self.curr_item
+
+    def _validate_colorscheme(self, colorscheme):
+        """Validate the color scheme against OpenSCAD's supported schemes."""
+        valid_schemes = [
+            'Cornfield', 'Metallic', 'Sunset', 'Starnight', 'ClearSky', 'BeforeDawn', 'Nature', 'Daylight Gem', 'Nocturnal Gem', 
+            'DeepOcean', 'Solarized', 'Tomorrow', 'Tomorrow Night' 
+        ]
+        if colorscheme not in valid_schemes:
+            errorlog.add_entry(self.RCFILE, 0, f"Invalid ColorScheme '{colorscheme}' in {self.RCFILE}. Using 'Cornfield'.", ErrorLog.WARNING)
+            return 'Cornfield'
+        return colorscheme
 
     def _skip_lines(self, lines, line_num=0):
         while line_num < len(lines):
@@ -203,6 +215,14 @@ class DocsGenParser(object):
             origin = OriginInfo(src_file, hdr_line_num+1)
             if title == "DefineHeader":
                 self._define_blocktype(subtitle, meta)
+            elif title == "ColorScheme":
+                if origin.file != self.RCFILE:
+                    raise DocsGenException(title, f"Block disallowed outside of {self.RCFILE} file:")
+                if body:
+                    raise DocsGenException(title, "Body not supported, while declaring block:")
+                if not subtitle:
+                    raise DocsGenException(title, "Must provide a color scheme (e.g., Tomorrow), while declaring block:")
+                self.default_colorscheme = self._validate_colorscheme(subtitle.strip())
             elif title == "IgnoreFiles":
                 if origin.file != self.RCFILE:
                     raise DocsGenException(title, "Block disallowed outside of {} file:".format(self.RCFILE))


### PR DESCRIPTION
This pull request introduces support for specifying a color scheme in the openscad-mdimggen tool, enabling consistent rendering of documentation images with a default color scheme, as used in openscad_docsgen example annotations (e.g., Example(3D,ColorScheme=Tomorrow)). 

## Key Changes:

- Updated .openscad_mdimggen_rc:
  - Added a default ColorScheme: to the YAML configuration file, allowing users to specify the rendering color scheme.
  - Ensured compatibility with existing fields (e.g., source_files, docs_dir, image_root).
- Modified mdimggen.py:
  - Added a -C/--colorscheme command-line argument to argparse, defaulting to the ColorScheme value from .openscad_mdimggen_rc or "Tomorrow".
   - Extended MarkdownImageGen.processFiles to pass the colorscheme parameter to image_manager.new_request, enabling OpenSCAD to render images with the specified color scheme (e.g., --colorscheme Tomorrow). 
- Dependency on feature/default-colorscheme:
   - Merged changes from feature/default-colorscheme
