### PR TITLE
Add Support for openscad-Log Blocks in mdimggen.py

### DIFF
--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -883,7 +883,6 @@ class LogBlock(GenericBlock):
             else:
                 script_lines.append(line)
         self.raw_script = script_lines
-
         self.generate_log()
 
     def generate_log(self):
@@ -892,8 +891,9 @@ class LogBlock(GenericBlock):
             self.raw_script,
             starting_cb=self._log_proc_start,
             completion_cb=self._log_proc_done,
-            verbose=True  # Enable verbose logging for debugging
+            verbose=True  
         )
+        log_manager.process_requests()
 
     def _log_proc_start(self, req):
         print("  Processing log for {}:{}... ".format(self.origin.file, self.origin.line), end='')
@@ -905,15 +905,20 @@ class LogBlock(GenericBlock):
             print("SUCCESS")
         else:
             self.log_output = []
-            print("FAIL")
+            #print("FAIL")
+            print("FAIL: " + "\n".join(req.errors + req.warnings))
         sys.stdout.flush()
 
     def get_file_lines(self, controller, target):
         out = []
-        if self.log_output:
+        #if self.log_output:
+        if self.log_request.success and self.log_request.echos:    
             #out.extend(target.block_header("Log Output", ""))
             out.extend(target.block_header(self.log_title, ""))
-            out.extend(target.markdown_block(["```log"] + self.log_output + ["```"]))
+            # out.extend(target.markdown_block(["```log"] + self.log_output + ["```"]))
+            out.extend(target.markdown_block(["```log"] + self.log_request.echos + ["```"]))
+        else:
+            print(f"WARNING: No log output for {self.origin.file}:{self.origin.line}")    
         return out
 
 class ImageBlock(GenericBlock):

--- a/openscad_docsgen/logmanager.py
+++ b/openscad_docsgen/logmanager.py
@@ -61,7 +61,6 @@ class LogRequest(object):
                 self.warnings.append(line)
             elif "ERROR:" in line:
                 self.errors.append(line)
-
         if self.completion_cb:
             self.completion_cb(self)
 

--- a/openscad_docsgen/mdimggen.py
+++ b/openscad_docsgen/mdimggen.py
@@ -12,6 +12,7 @@ import platform
 
 from .errorlog import errorlog, ErrorLog
 from .imagemanager import image_manager
+from .logmanager import log_manager
 from .filehashes import FileHashes
 
 
@@ -52,6 +53,11 @@ class MarkdownImageGen(object):
         errorlog.add_entry(req.src_file, req.src_line, out, ErrorLog.FAIL)
         sys.stderr.flush()
 
+    def log_completed(self, req):
+        if not req.success:
+            out = "\n".join(req.errors + req.warnings)
+            errorlog.add_entry(req.src_file, req.src_line, out, ErrorLog.FAIL)
+
     def processFiles(self, srcfiles):
         opts = self.opts
         image_root = os.path.join(opts.docs_dir, opts.image_root)
@@ -62,6 +68,7 @@ class MarkdownImageGen(object):
             sys.stdout.flush()
 
             out = []
+            log_requests = []
             with open(infile, "r") as f:
                 script = []
                 extyp = ""
@@ -72,9 +79,14 @@ class MarkdownImageGen(object):
                 for line in f.readlines():
                     linenum += 1
                     line = line.rstrip("\n")
-                    if line.startswith("```openscad"):
+                    if line.startswith("```openscad-log"):
+                        in_script = True
+                        is_log_block = True
+                        script = []                        
+                    elif line.startswith("```openscad"):
                         in_script = True;
-                        if "-" in line:
+                        is_log_block = False
+                        if "-" in line and not line.startswith("```openscad-log"):
                             extyp = line.split("-")[1]
                         else:
                             extyp = ""
@@ -84,30 +96,45 @@ class MarkdownImageGen(object):
                     elif in_script:
                         if line == "```":
                             in_script = False
-                            if opts.png_animation:
-                                fext = "png"
-                            elif any(x in extyp for x in ("Anim", "Spin")):
-                                fext = "gif"
-                            else:
-                                fext = "png"
-                            fname = "{}_{}.{}".format(fileroot, imgnum, fext)
-                            img_rel_url = os.path.join(opts.image_root, fname)
-                            imgfile = os.path.join(opts.docs_dir, img_rel_url)
-                            image_manager.new_request(
-                                fileroot+".md", linenum,
-                                imgfile, script, extyp,
-                                starting_cb=self.img_started,
-                                completion_cb=self.img_completed
-                            )
-                            if show_script:
-                                out.append("```openscad")
-                                for line in script:
-                                    if not line.startswith("--"):
-                                        out.append(line)
-                                out.append("```")
-                            out.append("![Figure {}]({})".format(imgnum, img_rel_url))
+                            if is_log_block:
+                                req = log_manager.new_request(
+                                    infile, linenum, script,
+                                    completion_cb=self.log_completed,
+                                    verbose=True
+                                )
+                                log_manager.process_requests()
+                                out.append("```log")
+                                if req.success and req.echos:
+                                    out.extend(req.echos)
+                                else:
+                                    out.append("No log output generated.")
+                                out.append("```")    
+                            else:    
+                                if opts.png_animation:
+                                    fext = "png"
+                                elif any(x in extyp for x in ("Anim", "Spin")):
+                                    fext = "gif"
+                                else:
+                                    fext = "png"
+                                fname = "{}_{}.{}".format(fileroot, imgnum, fext)
+                                img_rel_url = os.path.join(opts.image_root, fname)
+                                imgfile = os.path.join(opts.docs_dir, img_rel_url)
+                                image_manager.new_request(
+                                    fileroot+".md", linenum,
+                                    imgfile, script, extyp,
+                                    starting_cb=self.img_started,
+                                    completion_cb=self.img_completed
+                                )
+                                if show_script:
+                                    out.append("```openscad")
+                                    for line in script:
+                                        if not line.startswith("--"):
+                                            out.append(line)
+                                    out.append("```")
+                                out.append("![Figure {}]({})".format(imgnum, img_rel_url))
                             show_script = True
                             extyp = ""
+                            is_log_block = False
                         else:
                             script.append(line)
                     else:
@@ -121,7 +148,9 @@ class MarkdownImageGen(object):
             has_changed = self.filehashes.is_changed(infile)
             if opts.force or opts.test_only or has_changed:
                 image_manager.process_requests(test_only=opts.test_only)
+                log_manager.process_requests(test_only=opts.test_only)
             image_manager.purge_requests()
+            log_manager.purge_requests()
 
             if errorlog.file_has_errors(infile):
                 self.filehashes.invalidate(infile)


### PR DESCRIPTION
## Description:

This PR introduces support for openscad-log blocks in Markdown files processed by mdimggen.py. The new feature allows users to include OpenSCAD code in openscad-log blocks, which are executed to capture and display ECHO output (e.g., debug or metadata information) in the generated Markdown as a formatted log block. This enhances documentation by enabling the display of OpenSCAD log output alongside rendered images and code.

### Changes:

- Added handling for openscad-log blocks in mdimggen.py:
   - Detects openscad-log blocks and creates a log_manager request to execute the OpenSCAD script.
   - Processes log requests immediately to capture ECHO output (req.echos).
   - Outputs the log content as a ````logblock .
   - Includes a fallback message ("No log output generated.") if the request fails or produces no output.
   - Leverages existing LogBlock class in blocks.py and LogRequest in logmanager.py for log processing provided in PR feature/log-extractor

**Related Files**:
- `mdimggen.py`: Updated to add `openscad-Log` block processing.
- `blocks.py`: Relies on `LogBlock` for potential future integration in `openscad_docsgen` pipeline.
- `logmanager.py`: Uses `LogRequest` for executing OpenSCAD scripts and capturing `ECHO` output.


   
**Checklist**:
- [x] Tested with sample Markdown files containing `openscad-Log` blocks.
- [x] Verified log output in generated Markdown matches console `ECHO` capture.
- [x] Ensured compatibility with `openscad` blocks and image generation.   